### PR TITLE
Support custom runner system message

### DIFF
--- a/src/runners/workgpt/prompt.ts
+++ b/src/runners/workgpt/prompt.ts
@@ -4,13 +4,15 @@ import { ChatMessage, ChatRequest } from '../../chat-agents/types'
 export function buildInitialPrompt({
   apis,
   directive,
+  systemMessage,
 }: {
   apis: ApiInterface[]
   directive: string
+  systemMessage?: string
 }): ChatRequest {
   const messages: ChatMessage[] = [
     {
-      content: `You are WorkGpt, a helpful assistant that performs tasks.`,
+      content: systemMessage ?? `You are WorkGpt, a helpful assistant that performs tasks.`,
       role: 'system',
     },
     {

--- a/src/runners/workgpt/workgpt.ts
+++ b/src/runners/workgpt/workgpt.ts
@@ -22,8 +22,8 @@ export class WorkGptRunner extends Runner {
     this.apis = apis
   }
 
-  async runWithDirective(directive: string) {
-    return this.run(buildInitialPrompt({ apis: this.apis, directive }))
+  async runWithDirective(directive: string, systemMessage?: string) {
+    return this.run(buildInitialPrompt({ apis: this.apis, directive, systemMessage }))
   }
 
   async call(message: ChatResponse): Promise<ChatMessage> {


### PR DESCRIPTION
This is useful for adding additional details like the current date (your default should also have the current date).

I'm not in love with the system message string as an unnamed argument but figured it'd be easy for you to decide since this is such a small change.